### PR TITLE
changes to spacing and alignment on different viewports

### DIFF
--- a/app/views/beads/index.html.erb
+++ b/app/views/beads/index.html.erb
@@ -1,6 +1,6 @@
 <div class="container">
   <p style="color: green"><%= notice %></p>
-  <div class= "row mt-5 pt-5 pb-5 my-auto">
+  <div class= "row mt-5 pt-5 pb-5">
     <div class="col-lg-6 col-md-4 col-sm-6">
       <h6 class= "display-5">Beads</h6>
     </div>

--- a/app/views/devise/registrations/edit.html.erb
+++ b/app/views/devise/registrations/edit.html.erb
@@ -1,5 +1,5 @@
-<div class="container">
-  <h2 class="display-5 mt-5 mb-3">Edit <%= resource_name.to_s.humanize %></h2>
+<div class="container pt-5">
+  <h2 class="display-6 mt-5 pb-5">Edit <%= resource_name.to_s.humanize %></h2>
 
   <%= form_for(resource, as: resource_name, url: registration_path(resource_name), html: { method: :put }, local: true, data: { turbo: false }) do |f| %>
     <%= render "devise/shared/error_messages", resource: resource %>

--- a/app/views/devise/registrations/new.html.erb
+++ b/app/views/devise/registrations/new.html.erb
@@ -1,4 +1,4 @@
-<div class="container">
+<div class="container pt-5">
   <h2 class="display-5 mt-5 mb-3">Sign up</h2>
 
   <%= form_for(resource, as: resource_name, url: registration_path(resource_name), local: true, data: { turbo: false })  do |f| %>

--- a/app/views/dmcs/index.html.erb
+++ b/app/views/dmcs/index.html.erb
@@ -15,9 +15,9 @@
   </div>
   <div class="row align-items-start">
     <% @dmcs.sort_by{|dmc| dmc.number}.each do |dmc| %>
-      <div class="col-lg-2 col-md-3 col-sm-12">
+      <div class="col-lg-3 col-md-4 col-sm-6">
         <div class="card-deck">
-          <div id="dmcs" class="card mb-5 text-center" style="width: 10rem;">
+          <div id="dmcs" class="card mb-5 text-center" style="width: 12rem;">
             <% if dmc.image.present? %>
               <%= image_tag dmc.image, class: "card-img-top" %>
             <% end %>

--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -29,7 +29,7 @@
         </li> 
 
         <li>
-          <%= link_to "My Patterns", patterns_path, class: "nav-link mx-3" %>
+          <%= link_to "My Patterns", patterns_path, class: "nav-link" %>
         </li>
 
         <ul class="nav nav-login">    

--- a/app/views/metallics/index.html.erb
+++ b/app/views/metallics/index.html.erb
@@ -1,6 +1,6 @@
 <div class="container">
   <p style="color: green"><%= notice %></p>
-  <div class= "row mt-5 pt-5 pb-5 my-auto">
+  <div class= "row mt-5 pt-5 pb-5">
     <div class="col-lg-4 col-md-4 col-sm-6">
       <h5 class= "display-5">Metallic Threads</h5>
     </div>
@@ -15,9 +15,9 @@
   </div>
   <div class="row align-items-start">
     <% @metallics.sort_by{|metallic| metallic.number}.each do |metallic| %>
-      <div class="col-lg-3 col-md-4 col-sm-12">
+      <div class="col-lg-3 col-md-4 col-sm-6">
         <div class="card-deck">
-          <div id="metallics" class="card mb-5 text-center" style="width: 12rem;">
+          <div id="metallics" class="card mb-5 text-center" style="width: 14rem;">
             <% if metallic.image.present? %>
               <%= image_tag metallic.image, class: "card-img-top" %>
             <% end %>

--- a/app/views/metallics/show.html.erb
+++ b/app/views/metallics/show.html.erb
@@ -16,9 +16,9 @@
               <i  class="bi bi-bag-x-fill text-danger"></i>
             <% end %>
           </h5> 
-          <p class="card-title"><%= "Color: #{@metallic.color}"%></p>
-          <p class="card-title"><%= "Brand: #{@metallic.brand}"%></p> 
-          <p class="card-title"><%= "Patterns: #{@metallic.pattern}" %></p>
+          <p class="card-title"><%= "Color:  #{@metallic.color}"%></p>
+          <p class="card-title"><%= "Brand:  #{@metallic.brand}"%></p>
+          <p class="card-title"><%= "All Patterns:  #{@metallic.pattern}" %></p>
           <div class="mb-5">
             <%= link_to "Edit Metallic", edit_metallic_path(@metallic), class: "btn btn-secondary float-start"%>
             <%= button_to "Delete Metallic", @metallic, method: :delete, class: "btn btn-outline-danger ms-3 float-start" %>

--- a/app/views/patterns/index.html.erb
+++ b/app/views/patterns/index.html.erb
@@ -1,6 +1,6 @@
 <div class="container">
   <p style="color: green"><%= notice %></p>
-  <div class= "row mt-5 pt-5 pb-5 my-auto">
+  <div class= "row mt-5 pt-5 pb-5">
     <div class="col-lg-4 col-md-4 col-sm-6">
       <h5 class= "display-5">Patterns</h5>
     </div>


### PR DESCRIPTION
### Screenshot of changes to the alignment of Metallics Index pages on different viewports
<img width="1162" alt="Screen Shot 2023-02-12 at 10 43 51 AM" src="https://user-images.githubusercontent.com/23530380/218330551-0b156c5e-35af-49d6-b4d6-6abf37d93d36.png">
<img width="415" alt="Screen Shot 2023-02-12 at 10 43 16 AM" src="https://user-images.githubusercontent.com/23530380/218330562-967cb14f-d311-48e6-acfd-74b119031ada.png">

### Screenshot of changes to the alignment of DMC Index page on the Desktop viewport
<img width="1697" alt="Screen Shot 2023-02-12 at 10 44 17 AM" src="https://user-images.githubusercontent.com/23530380/218330643-e77ec606-8384-4157-ae5a-472456c58df7.png">
